### PR TITLE
fix required ruby version used by cocoapods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby "2.2.3"
 
 gem 'cocoapods'
 gem 'cocoapods-keys'


### PR DESCRIPTION
Ao executar os passos de instalação de acordo com o README, o Cocoapods quebra.

As versões atuais do Podfile requer Ruby v 2.2.3, pelo menos, [de acordo com a issue do cocoapods](https://github.com/CocoaPods/CocoaPods/issues/5200)

Pra garantir, bastei alterar o Gemfile com a versão mínima requerida. :)
